### PR TITLE
Tweaked astro.config.js to use Vercel SSG in hybrid mode

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,6 @@ export default defineConfig({
   //base: '/code-oasis-website',
   ,
 
-  output: "server",
+  output: "hybrid",
   adapter: vercel()
 });


### PR DESCRIPTION
The site isn't loading any dynamic content, or calling any endpoints, so it seems better approach to make most of the pages Static & opt in to [hybrid mode](https://docs.astro.build/en/guides/server-side-rendering/#configuring-individual-routes)

In case some pages require dynamic content, use
```astro
---
export const prerender = true;
---
```